### PR TITLE
Add Directory Provider Version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The system used for saving data.
 
 Saves data using folders. This is a reliable and quick method but creates many files on your system. It may not be ideal in some situations like with cloud saves.
 
+#### Directory V2
+
+Similar to [Directory](#Directory) but uses less resources and is faster.
+
 #### File
 
 Saves data using a fixed number of files, currently 2, but it's slower and wastes memory compared to Directory.
@@ -46,7 +50,7 @@ Saves data using a fixed number of files, currently 2, but it's slower and waste
 | **Provider**   | **Status**   | **Storage** | **Performance** | **Files**                 | **Folders**                                     |
 |----------------|--------------|-------------|-----------------|---------------------------|-------------------------------------------------|
 | _Directory_    | Stable       | Medium      | Medium          | 2 for each key+value pair | 1 for each key+value pair 1 for each unique key |
-| _Directory V2_ | Planned      | Small       | Fast            | 1 for each key+value      | 1 for each unique key                           |
+| _Directory V2_ | Stable       | Small       | Fast            | 1 for each key+value      | 1 for each unique key                           |
 | _Files_        | Planned      | Medium      | Medium          | 1 for each key            | 1                                               |
 | _File_         | Experimental | Large       | Slow            | 2                         | 1                                               |
 

--- a/addons/EZStorage/directory2_provider.gd
+++ b/addons/EZStorage/directory2_provider.gd
@@ -1,0 +1,200 @@
+extends "storage_provider.gd"
+
+var migration_name := "migration".sha256_text()
+
+
+func _hash(s: String) -> String:
+	if OS.is_debug_build() and Settings.get_debug_filenames():
+		return s.http_escape()
+	return s.sha256_text()
+
+
+class Command:
+	func execute(_root: String) -> bool:
+		return false
+
+	func encode() -> Dictionary:
+		return {"command": ""}
+
+
+class StoreCommand:
+	extends Command
+
+	var section: String
+	var key: String
+	var value: PoolByteArray
+
+	func _init(section: String, key: String, value: PoolByteArray):
+		self.section = section
+		self.key = key
+		self.value = value
+
+	func execute(root: String) -> bool:
+		var path := root.plus_file(section)
+		var dir := Directory.new()
+		var rc := dir.make_dir_recursive(path)
+		assert(rc == OK)
+
+		var file := File.new()
+		rc = file.open(path.plus_file(key), File.WRITE)
+		if rc != OK:
+			printerr("Could not create file: ", rc)
+			return false
+
+		file.store_buffer(value)
+		file.close()
+		return true
+
+	func encode() -> Dictionary:
+		return {"command": "store", "section": section, "key": key, "value": value}
+
+
+class PurgeCommand:
+	extends Command
+
+	var section: String
+	var key: String
+
+	func _init(section: String, key: String):
+		self.section = section
+		self.key = key
+
+	func execute(root: String) -> bool:
+		var path := root
+		if not section.empty():
+			path = path.plus_file(section)
+			if not key.empty():
+				path = path.plus_file(key)
+
+		return _directory_remove_recursive(path)
+
+	func encode() -> Dictionary:
+		return {"command": "purge", "section": section, "key": key}
+
+	static func _directory_remove_recursive(path: String) -> bool:
+		var directory := Directory.new()
+
+		if directory.file_exists(path):
+			directory.remove(path)
+			return not directory.file_exists(path)
+
+		if directory.dir_exists(path):
+			if directory.open(path) == OK:
+				if directory.list_dir_begin(true) != OK:
+					return false
+				var file_name := directory.get_next()
+				while file_name != "":
+					if directory.current_is_dir():
+						if not _directory_remove_recursive(path.plus_file(file_name)):
+							return false
+					else:
+						if directory.remove(file_name) != OK:
+							return false
+					file_name = directory.get_next()
+
+				if directory.remove(path) != OK:
+					return false
+			else:
+				return false
+		else:
+			return false
+
+		return true
+
+
+func decode(buffer: Dictionary) -> Command:
+	match buffer["command"]:
+		"store":
+			return StoreCommand.new(buffer["section"], buffer["key"], buffer["value"])
+		"purge":
+			return PurgeCommand.new(buffer["section"], buffer["key"])
+	return null
+
+
+func run_migration():
+	var dir := Directory.new()
+	var migration_path := get_root().plus_file(migration_name)
+	if dir.file_exists(migration_path):
+		var file := File.new()
+		file.open(migration_path, File.READ)
+		var command = bytes2var(file.get_buffer(file.get_len())) as Dictionary
+		file.close()
+		if command:
+			decode(command).execute(get_root())
+
+		var rc := dir.remove(migration_path)
+		assert(not dir.file_exists(migration_path))
+
+
+func execute(command: Command) -> bool:
+	var dir := Directory.new()
+	var rc := dir.make_dir_recursive(get_root())
+	assert(rc == OK, "Could not create base directory.")
+	var file := File.new()
+	var migration_path := get_root().plus_file(migration_name)
+	rc = file.open(migration_path, File.WRITE)
+	assert(rc == OK, "Could not create migration file.")
+
+	file.store_buffer(var2bytes(command.encode()))
+	file.close()
+
+	var result := command.execute(get_root())
+
+	dir.remove(migration_path)
+	assert(not dir.file_exists(migration_path))
+
+	return result
+
+
+func copy_to(_src: String, _dst: String):
+	pass
+
+
+func store(section: String, key: String, value) -> bool:
+	run_migration()
+	var command := StoreCommand.new(_hash(section), _hash(key), var2bytes(value))
+	return execute(command)
+
+
+func fetch(section: String, key: String, default = null):
+	run_migration()
+	var directory := Directory.new()
+	var path := get_root().plus_file(_hash(section))
+	if not directory.dir_exists(path):
+		return default
+
+	var file := File.new()
+	var res := file.open(path.plus_file(_hash(key)), File.READ)
+	if res != OK:
+		return default
+	var data := file.get_buffer(file.get_len())
+	return bytes2var(data)
+
+
+func purge(section := "", key := "") -> bool:
+	run_migration()
+	var command := PurgeCommand.new(_hash(section), _hash(key))
+	return execute(command)
+
+
+static func _get_files(path) -> PoolStringArray:
+	var files := PoolStringArray()
+	var directory := Directory.new()
+
+	if directory.open(path) == OK:
+		if directory.list_dir_begin(true) != OK:
+			return files
+		var file_name := directory.get_next()
+		while file_name != "":
+			files.append(file_name.get_file().http_unescape())
+			file_name = directory.get_next()
+
+	return files
+
+
+func get_sections() -> PoolStringArray:
+	return _get_files(get_root())
+
+
+func get_keys(section: String) -> PoolStringArray:
+	return _get_files(get_root().plus_file(_hash(section)))

--- a/addons/EZStorage/directory_provider.gd
+++ b/addons/EZStorage/directory_provider.gd
@@ -65,20 +65,27 @@ func purge(section := "", key := "") -> bool:
 static func _directory_remove_recursive(path: String) -> bool:
 	var directory := Directory.new()
 
-	if directory.open(path) == OK:
-		if directory.list_dir_begin(true) != OK:
-			return false
-		var file_name := directory.get_next()
-		while file_name != "":
-			if directory.current_is_dir():
-				if not _directory_remove_recursive(path.plus_file(file_name)):
-					return false
-			else:
-				if directory.remove(file_name) != OK:
-					return false
-			file_name = directory.get_next()
+	if directory.file_exists(path):
+		directory.remove(path)
+		return not directory.file_exists(path)
 
-		if directory.remove(path) != OK:
+	if directory.dir_exists(path):
+		if directory.open(path) == OK:
+			if directory.list_dir_begin(true) != OK:
+				return false
+			var file_name := directory.get_next()
+			while file_name != "":
+				if directory.current_is_dir():
+					if not _directory_remove_recursive(path.plus_file(file_name)):
+						return false
+				else:
+					if directory.remove(file_name) != OK:
+						return false
+				file_name = directory.get_next()
+
+			if directory.remove(path) != OK:
+				return false
+		else:
 			return false
 	else:
 		return false

--- a/addons/EZStorage/ezstorage.gd
+++ b/addons/EZStorage/ezstorage.gd
@@ -3,6 +3,7 @@ extends Node
 const Settings := preload("settings.gd")
 const StorageProvider := preload("storage_provider.gd")
 const DirectoryProvider := preload("directory_provider.gd")
+const Directory2Provider := preload("directory2_provider.gd")
 const FileProvider := preload("file_provider.gd")
 
 var provider := get_storage_provider()
@@ -12,6 +13,8 @@ static func get_storage_provider() -> StorageProvider:
 	match Settings.get_storage_provider():
 		Settings.StorageProviderType.DIRECTORY:
 			return DirectoryProvider.new()
+		Settings.StorageProviderType.DIRECTORY_V2:
+			return Directory2Provider.new()
 		Settings.StorageProviderType.FILE:
 			return FileProvider.new()
 

--- a/addons/EZStorage/settings.gd
+++ b/addons/EZStorage/settings.gd
@@ -1,6 +1,6 @@
 extends Resource
 
-enum StorageProviderType { DIRECTORY, FILE }
+enum StorageProviderType { DIRECTORY, DIRECTORY_V2, FILE }
 
 const DIRECTORY_NAME := "application/storage/directory"
 const DIRECTORY_DEFAULT := "user://data"


### PR DESCRIPTION
The new directory provider uses half as many files and folder and the files are half the size. This results in files being 1/4 the size of v1.

This is accomplished with a migration system. A simple migration file is use to run transactional changes for each update. There is some overhead for this system but expect better performance than v1 regardless.