### PR TITLE
Delete resources when section is empty

### DIFF
--- a/addons/EZStorage/directory2_provider.gd
+++ b/addons/EZStorage/directory2_provider.gd
@@ -113,6 +113,8 @@ func purge_section(section: String, skip_keys: PoolStringArray) -> bool:
 			continue
 		var command := PurgeCommand.new(Util.hash_filename(section), dir)
 		all_success = Util.execute(get_root(), command) and all_success
+	var dir := Directory.new()
+	dir.remove(get_root().plus_file(Util.hash_filename(section)))
 	return all_success
 
 

--- a/addons/EZStorage/files_provider.gd
+++ b/addons/EZStorage/files_provider.gd
@@ -99,11 +99,15 @@ func purge(skip_sections: PoolStringArray) -> bool:
 
 func purge_section(section: String, skip_keys: PoolStringArray) -> bool:
 	var keys := read_section(section)
-	for key in keys:
+	for key in keys.keys():
 		if key in skip_keys:
 			continue
 		keys.erase(key)
-	var command := StoreCommand.new(Util.hash_filename(section), keys)
+	var command: Util.Command
+	if keys.empty():
+		command = PurgeCommand.new(Util.hash_filename(section))
+	else:
+		command = StoreCommand.new(Util.hash_filename(section), keys)
 	return Util.execute(get_root(), command)
 
 

--- a/tests/EZStorage.gd
+++ b/tests/EZStorage.gd
@@ -168,7 +168,7 @@ func test_directory2_storage() -> void:
 	assert_eq(list_storage_dir(), map_to_directory2_storage([sk("game", ["highscore", "pi"]), sk("hello", ["world"])]))
 
 	assert(EZStorage.purge_section("game"))
-	assert_eq(list_storage_dir(), map_to_directory2_storage([sk("game", []), sk("hello", ["world"])]))
+	assert_eq(list_storage_dir(), map_to_directory2_storage([sk("hello", ["world"])]))
 
 	assert(EZStorage.purge())
 	assert_eq(list_storage_dir(), map_to_directory2_storage([]))
@@ -210,7 +210,7 @@ func test_files_storage() -> void:
 	assert_eq(list_storage_dir(), map_to_files_storage([sk("game", ["highscore", "pi"]), sk("hello", ["world"])]))
 
 	assert(EZStorage.purge_section("game"))
-	assert_eq(list_storage_dir(), map_to_files_storage([sk("game", []), sk("hello", ["world"])]))
+	assert_eq(list_storage_dir(), map_to_files_storage([sk("hello", ["world"])]))
 
 	assert(EZStorage.purge())
 	assert_eq(list_storage_dir(), map_to_files_storage([]))


### PR DESCRIPTION
Some folders/files are left behind. Clean up things that are no longer needed.