### PR TITLE
Duplicate Dictionary and Array in files provider

### DIFF
--- a/addons/EZStorage/files_provider.gd
+++ b/addons/EZStorage/files_provider.gd
@@ -85,7 +85,7 @@ func copy_to(_src: String, _dst: String):
 func store(section: String, key: String, value) -> bool:
 	Util.run_migration(get_root(), decoder)
 	var keys := read_section(section)
-	keys[key] = value
+	keys[key] = Util.duplicate(value)
 	var command := StoreCommand.new(Util.hash_filename(section), keys)
 	return Util.execute(get_root(), command)
 
@@ -93,7 +93,7 @@ func store(section: String, key: String, value) -> bool:
 func fetch(section: String, key: String, default = null):
 	Util.run_migration(get_root(), decoder)
 	var keys := read_section(section)
-	return keys.get(key, default)
+	return Util.duplicate(keys.get(key, default))
 
 
 func purge(skip_sections: PoolStringArray) -> bool:

--- a/addons/EZStorage/plugin.cfg
+++ b/addons/EZStorage/plugin.cfg
@@ -3,5 +3,5 @@
 name="EZStorage"
 description="Easily store/fetch data using key-value storage."
 author="mashumafi"
-version="1.0.0"
+version="1.0.1"
 script="plugin.gd"

--- a/addons/EZStorage/util.gd
+++ b/addons/EZStorage/util.gd
@@ -25,6 +25,12 @@ static func hash_filenames(s: PoolStringArray) -> PoolStringArray:
 	return s
 
 
+static func duplicate(value):
+	if value is Array or value is Dictionary:
+		return value.duplicate()
+	return value
+
+
 static func decode(buffer: Array, decoder: Dictionary) -> Command:
 	if buffer.empty():
 		return null
@@ -114,7 +120,7 @@ class Cache:
 	var tail: Link
 	var lookup: Dictionary
 	var size: int
-	var links_pool : ObjectPool
+	var links_pool: ObjectPool
 
 	class Link:
 		extends Object

--- a/tests/EZStorage.gd
+++ b/tests/EZStorage.gd
@@ -215,26 +215,6 @@ func test_files_storage() -> void:
 	assert(EZStorage.purge())
 	assert_eq(list_storage_dir(), map_to_files_storage([]))
 
-	# Test the cache
-	var dicts := []
-	dicts.resize(30)
-	for i in range(dicts.size()):
-		var dict := {}
-		dicts[i] = dict
-		EZStorage.store(str(i), "dict", dict)
-	for i in range(dicts.size()):
-		assert(EZStorage.fetch(str(i), "dict") == dicts[i])
-
-	for i in range(dicts.size()):
-		var dict := {}
-		dicts[i] = dict
-		EZStorage.store(str(i+100), "dict", dict)
-	for i in range(dicts.size()):
-		assert(EZStorage.fetch(str(i), "dict") != dicts[i])
-
-	assert(EZStorage.purge())
-	assert_eq(list_storage_dir(), map_to_files_storage([]))
-
 class CacheListener:
 	var changes := []
 	func _changed(key, section):


### PR DESCRIPTION
Files provider should not share it's references but instead use copies instead. This makes the LRU cache immutable.